### PR TITLE
Ansible 2.9 support, update travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,52 @@
 ---
 language: python
-python: "2.7"
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq python-apt python-pycurl
+
+services:
+  - docker
+
+matrix:
+  fast_finish: true
+
+env:
+  - IMAGE_BUILD_PLATFORM=stable-centos7
+  - IMAGE_BUILD_PLATFORM=devel-centos7
+#  - IMAGE_BUILD_PLATFORM=epel-centos7
+
 install:
-  - pip install ansible
-  - echo -e 'localhost  ansible_connection=local' > tests/inventory
-  - echo -e '[defaults]\nroles_path = ../\nhostfile = ./tests/inventory' > ansible.cfg
+  - npm install -g validate-dockerfile
+
+before_script:
+  # TESTDIR = Where the stable-centos/Dockerfile is located
+  - export TESTDIR=tests
+  # ROLETOTEST = The name of this repo
+  - export ROLETOTEST=$(basename $(pwd))
+  - export COMMIT=${TRAVIS_COMMIT::8}
+  # The tag we assign the docker image we build with the Dockerfile
+  - export REPO=csc/ansible
+  # https://www.npmjs.com/package/validate-dockerfile - validate the Dockerfile
+  - docklint ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/Dockerfile
+  # Build the image
+  - docker build -t ${REPO}:${IMAGE_BUILD_PLATFORM} ${TESTDIR}/${IMAGE_BUILD_PLATFORM}/
+  # Launch the container
+  - docker run --privileged -d -ti -e "container=docker"  -v `pwd`:/$ROLETOTEST -v /sys/fs/cgroup:/sys/fs/cgroup  ${REPO}:${IMAGE_BUILD_PLATFORM}  /usr/sbin/init
+  - DOCKER_CONTAINER_ID=$(docker ps | grep ${IMAGE_BUILD_PLATFORM} | awk '{print $1}')
+  - docker logs $DOCKER_CONTAINER_ID
+  # Testing of this ansible-role:
 script:
-  - ansible-playbook --syntax-check tests/role.yml
-  - ansible-playbook --sudo -v --diff tests/role.yml
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c "/$ROLETOTEST/tests/test-in-docker-image.sh"
+after_script:
+  # Print some logs and other useful information for debugging travis:
   - >
-    ansible-playbook --sudo tests/role.yml
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+    docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'echo -ne "------\nEND ANSIBLE TESTS\n------\nSystemD Units:\n------\n";
+       systemctl --no-pager --all --full status ;
+       echo -ne "------\nJournalD Logs:\n------\n" ;
+       sudo journalctl --catalog --all --full --no-pager'
+  - docker exec -ti $DOCKER_CONTAINER_ID /bin/sh -c 'tree /ansible*'
+  - docker ps -a
+  - docker stop $DOCKER_CONTAINER_ID
+  - docker rm -v $DOCKER_CONTAINER_ID
+#after_success:
+#  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+notifications:
+  email: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,14 +78,14 @@
 
 - name: ensure the hostname entry for master is available for the client
   lineinfile: dest=/etc/hosts regexp="{{ mysql_repl_master }}" line="{{ mysql_repl_master + '   ' +  hostvars[mysql_repl_master].ansible_default_ipv4.address }}" state=present
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
 
 - name: get the current master servers replication status
   mysql_replication: mode=getmaster
   delegate_to: "{{ mysql_repl_master }}"
   register: repl_stat
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
 
 - name: change the master in slave to start the replication
   mysql_replication: mode=changemaster master_host={{ mysql_repl_master }} master_log_file={{ repl_stat.File }} master_log_pos={{ repl_stat.Position }} master_user={{ mysql_repl_user[0].name }} master_password={{ mysql_repl_user[0].pass }}
-  when: slave|failed and mysql_repl_role == 'slave' and mysql_repl_master is defined
+  when: slave is failed and mysql_repl_role == 'slave' and mysql_repl_master is defined

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -1,0 +1,42 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum makecache all && \
+    yum -y groups mark convert && \
+    yum -y groups mark install "Development Tools" && \
+    yum -y groups mark convert "Development Tools" && \
+    yum -y groupinstall "Development Tools" && \
+    yum -y install libffi-devel openssl-devel && \
+    yum -y install dbus-devel dbus-python-devel dbus dbus-glib dbus-glib-devel && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
+    pip install pysphere passlib dnspython && \
+    sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip && \
+    yum clean all && rm -rf /var/cache/yum
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost\n' > /etc/ansible/hosts
+RUN mkdir /opt/ansible/
+RUN git clone http://github.com/ansible/ansible.git /opt/ansible/ansible
+WORKDIR /opt/ansible/ansible
+# here one could checkout a specific commit
+#RUN git checkout f4af154beff2b281e464b616f504293d67187da5
+RUN git submodule update --init
+ENV PATH /opt/ansible/ansible/bin:/bin:/usr/bin:/sbin:/usr/sbin
+ENV PYTHONPATH /opt/ansible/ansible/lib
+ENV ANSIBLE_LIBRARY /opt/ansible/ansible/library
+# Workaround bug in pip / pylockfile: http://pad.lv/1472101
+# If HOME is a volume mount, causes infinite loop in pip trying to write lock
+ENV XDG_CACHE_HOME /tmp/
+RUN source /opt/ansible/ansible/hacking/env-setup
+
+
+CMD /bin/bash

--- a/tests/epel-centos7/Dockerfile
+++ b/tests/epel-centos7/Dockerfile
@@ -1,0 +1,18 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN yum -y install ansible
+
+CMD ["/bin/bash"]

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,32 @@
+# https://github.com/CSCfi/fgci-ansible/blob/master/examples/hosts-example
+localhost
+
+[login]
+localhost
+
+[admin]
+localhost
+
+[grid]
+localhost
+
+[install]
+localhost
+
+[compute]
+localhost ip_address=10.1.100.1 mac_address=00:11:22:33:44:55 pxe=yes
+
+[pxe_bootable_nodes:children]
+compute
+
+[production:children]
+install
+admin
+#login
+grid
+
+[slurm_service:children]
+install
+
+[slurm_compute:children]
+compute

--- a/tests/role.yml
+++ b/tests/role.yml
@@ -1,4 +1,0 @@
----
-- hosts: localhost
-  roles:
-  - ansible-role-mysql

--- a/tests/stable-centos7/Dockerfile
+++ b/tests/stable-centos7/Dockerfile
@@ -1,0 +1,21 @@
+# Latest version of centos
+FROM centos:centos7
+MAINTAINER James Cuzella <james.cuzella@lyraphase.com>
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y groupinstall "Development tools" && \
+    yum -y install python-devel MySQL-python sshpass && \
+    yum -y install acl sudo && \
+    sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
+    yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip \
+    pip install pyrax pysphere boto passlib dnspython && \
+    yum -y remove $(rpm -qa "*-devel") && \
+    yum -y groupremove "Development tools" && \
+    yum -y autoremove && \
+    yum -y install bzip2 crontabs file findutils gem git gzip hg procps-ng svn sudo tar tree which unzip xz zip
+
+RUN mkdir /etc/ansible/
+RUN echo -e '[local]\nlocalhost' > /etc/ansible/hosts
+RUN pip install ansible
+
+CMD ["/bin/bash"]

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+SOURCE="${BASH_SOURCE[0]}"
+RDIR="$( dirname "$SOURCE" )"
+SUDO=`which sudo 2> /dev/null`
+SUDO_OPTION=""
+#SUDO_OPTION="--sudo"
+OS_TYPE=${1:-}
+OS_VERSION=${2:-}
+ANSIBLE_VERSION=${3:-}
+
+ANSIBLE_VAR=""
+ANSIBLE_INVENTORY="tests/inventory"
+ANSIBLE_PLAYBOOk="tests/test.yml"
+#ANSIBLE_LOG_LEVEL=""
+ANSIBLE_LOG_LEVEL="-v"
+APACHE_CTL="apache2ctl"
+
+# if there wasn't sudo then ansible couldn't use it
+if [ "x$SUDO" == "x" ];then
+    SUDO_OPTION=""
+fi
+
+if [ "${OS_TYPE}" == "centos" ];then
+    APACHE_CTL="apachectl"
+    if [ "${OS_VERSION}" == "7" ];then
+        ANSIBLE_VAR="apache_use_service=False"
+    fi
+fi
+
+ANSIBLE_EXTRA_VARS=""
+if [ "${ANSIBLE_VAR}x" == "x" ];then
+    ANSIBLE_EXTRA_VARS=" -e \"${ANSIBLE_VAR}\" "
+fi
+
+
+cd $RDIR/..
+printf "[defaults]\nroles_path = ../:roles\ncallback_whitelist = profile_tasks" > ansible.cfg
+printf "" > ssh.config
+
+function show_version() {
+
+echo "TEST: show versions"
+ansible --version
+id
+systemctl --no-pager
+proc1comm=$(cat /proc/1/comm)
+echo "TEST: proc1s comm is $proc1comm"
+
+}
+
+function install_ansible_devel() {
+
+# http://docs.ansible.com/ansible/intro_installation.html#latest-release-via-yum
+
+echo "TEST: building ansible"
+
+yum -y install PyYAML python-paramiko python-jinja2 python-httplib2 rpm-build make python2-devel asciidoc patch wget 2>&1 >/dev/null || (echo "Could not install ansible yum dependencies" && exit 2 )
+rm -Rf ansible
+git clone https://github.com/ansible/ansible --recursive ||(echo "Could not clone ansible from Github" && exit 2 )
+cd ansible
+# checking out this commit because some errors after 2015-11-05
+#git checkout 07d0d2720c73816e1206882db7bc856087eb5c3f
+# because systemctl and systemd
+git checkout 589971fe7ef78ea8bb41fb9ae6cd19cb8e277371
+make rpm 2>&1 >/dev/null
+rpm -Uvh ./rpm-build/ansible-*.noarch.rpm ||(echo "Could not install built ansible devel rpms" && exit 2 )
+cd ..
+rm -Rf ansible
+
+}
+
+function install_os_deps() {
+echo "TEST: installing os deps"
+
+yum -y install epel-release sudo tree git which file less||(echo "Could not install some os deps" && exit 2 )
+
+}
+
+function tree_list() {
+
+tree
+
+}
+function test_ansible_setup(){
+    echo "TEST: ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost"
+
+    ansible -m setup -i ${ANSIBLE_INVENTORY} --connection=local localhost
+
+}
+
+
+function test_install_requirements(){
+    echo "TEST: ansible-galaxy install -r requirements.yml --force"
+
+    ansible-galaxy install -r requirements.yml --force ||(echo "requirements install failed" && exit 2 )
+
+}
+
+function test_playbook_syntax(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} --syntax-check ||(echo "ansible playbook syntax check was failed" && exit 2 )
+}
+
+function test_playbook_check(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check"
+
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} --check ||(echo "playbook check failed" && exit 2 )
+
+}
+
+function test_playbook(){
+    echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
+
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} | grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+}
+function extra_tests(){
+
+    echo "TEST: No-op. Not performing extra tests"
+}
+
+
+set -e
+function main(){
+#    install_os_deps
+#    install_ansible_devel
+    show_version
+#    tree_list
+#    test_install_requirements
+    test_ansible_setup
+    test_playbook_syntax
+    test_playbook
+    test_playbook_check
+    extra_tests
+
+}
+
+################ run #########################
+main

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,33 +2,7 @@
 
  - hosts: localhost
    remote_user: root
-   vars:
-     - collectd_chain_process_disable_some_metrics: False
-     - collectd_plugins_exec_custom:
-       - options:
-         - LoadPlugin: exec
-       - sections:
-         - name: Plugin
-           param: exec
-           content:
-            - options:
-              - Exec:
-                - nobody 
-                - /usr/local/bin/collectd_postgresql_db_sizes.sh
-              - Exec:
-                - nobody 
-                - /usr/local/bin/collectd_postgresql_db_connections.py
-     - collectd_global_options_custom: "{{
-         collectd_plugins_exec_custom
-       }}"
-     - collectd_prefix_rules:
-       - name: generic_prefix
-         regexp: "^hpc\\.myawesomeclustername\\."
-         invert_match: True
-         prefix: "hpc.myawesomeclustername."
-         stop: False
-
    roles:
-     - ansible-role-collectd
-   pre_tasks:
-     - debug: var=ansible_service_mgr
+     - ansible-role-mysql
+#   pre_tasks:
+#     - debug: var=ansible_service_mgr

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,34 @@
+---
+
+ - hosts: localhost
+   remote_user: root
+   vars:
+     - collectd_chain_process_disable_some_metrics: False
+     - collectd_plugins_exec_custom:
+       - options:
+         - LoadPlugin: exec
+       - sections:
+         - name: Plugin
+           param: exec
+           content:
+            - options:
+              - Exec:
+                - nobody 
+                - /usr/local/bin/collectd_postgresql_db_sizes.sh
+              - Exec:
+                - nobody 
+                - /usr/local/bin/collectd_postgresql_db_connections.py
+     - collectd_global_options_custom: "{{
+         collectd_plugins_exec_custom
+       }}"
+     - collectd_prefix_rules:
+       - name: generic_prefix
+         regexp: "^hpc\\.myawesomeclustername\\."
+         invert_match: True
+         prefix: "hpc.myawesomeclustername."
+         stop: False
+
+   roles:
+     - ansible-role-collectd
+   pre_tasks:
+     - debug: var=ansible_service_mgr


### PR DESCRIPTION
Change `|failed` to `is failed`.

Also bring state of travis tests up to speed with 2020. Mostly copied over from ansible-role-collectd.